### PR TITLE
Add product id to create payment instruction example

### DIFF
--- a/source/includes/_dynamic_discounting_payment_instructions.md
+++ b/source/includes/_dynamic_discounting_payment_instructions.md
@@ -2,7 +2,7 @@
 
 ```shell
 curl --header "Authorization: Bearer abcd" --header "Content-Type: application/json" --data '{}' \
-"https://api.novicap.com/v1/dynamic_discounting/payment_instructions"
+"https://api.novicap.com/v1/dynamic_discounting/payment_instructions?product_id=123"
 ```
 
 > The above command returns a JSON payload with the 201 CREATED status.


### PR DESCRIPTION
<!--
⚠️ 🚨 ⚠️  STOP AND READ THIS ⚠️ 🚨 ⚠️

👆👆 see that 'base fork' dropdown above? You should change it! The default value of "slatedocs/slate" submits your change to ALL USERS OF SLATE, not just your company. This is PROBABLY NOT WHAT YOU WANT.
-->